### PR TITLE
Add optional argument allowing to configure wait time for JVM to start.

### DIFF
--- a/container-se-managed/src/main/java/org/jboss/arquillian/container/se/managed/ManagedSEContainerConfiguration.java
+++ b/container-se-managed/src/main/java/org/jboss/arquillian/container/se/managed/ManagedSEContainerConfiguration.java
@@ -30,10 +30,19 @@ public class ManagedSEContainerConfiguration implements ContainerConfiguration {
     private Level logLevel = Level.INFO;
     private boolean keepDeploymentArchives = false;
     private String additionalJavaOpts;
+    private int waitTime  = 5;
 
     public void validate() throws ConfigurationException {
     }
 
+    public void setWaitTime(int waitTime) {
+        this.waitTime = waitTime;
+    }
+    
+    public int getWaitTime() {
+        return waitTime;
+    }
+    
     public boolean isDebug() {
         return debug;
     }

--- a/container-se-tests/src/test/resources/arquillian.xml
+++ b/container-se-tests/src/test/resources/arquillian.xml
@@ -10,6 +10,7 @@
          <property name="logLevel">INFO</property>
          <property name="debug">false</property>
          <property name="keepDeploymentArchives">false</property>
+         <property name="waitTime">5</property>
       </configuration>
    </container>
 


### PR DESCRIPTION
On slower machines (e.g. virtual ones), the wait time was too short and an exception was thrown.
This PR should allow to set a property in arquillian.xml and prolong the time, default time was left at 5 seconds.
I couldn't think of an automated test but I at least tested this via Jenkins.